### PR TITLE
Allow users to send an email from the about page.

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/AboutActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/AboutActivity.java
@@ -1,6 +1,7 @@
 package org.a5calls.android.a5calls.controller;
 
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -22,12 +23,10 @@ import org.a5calls.android.a5calls.BuildConfig;
 import org.a5calls.android.a5calls.FiveCallsApplication;
 import org.a5calls.android.a5calls.model.AccountManager;
 import org.a5calls.android.a5calls.model.FiveCallsApi;
-import org.a5calls.android.a5calls.model.Issue;
 import org.a5calls.android.a5calls.R;
 import org.a5calls.android.a5calls.util.CustomTabsUtil;
 
 import java.text.NumberFormat;
-import java.util.List;
 import java.util.Locale;
 
 import butterknife.BindView;
@@ -38,12 +37,14 @@ import butterknife.ButterKnife;
  */
 public class AboutActivity extends AppCompatActivity {
     private static final String TAG = "AboutActivity";
+    private static final String EMAIL_CONTENT_TYPE = "message/rfc822";
 
     private final AccountManager accountManager = AccountManager.Instance;
     private FiveCallsApi.CallRequestListener mStatusListener;
 
     @BindView(R.id.sign_up_newsletter_btn) Button signUpNewsletterButton;
     @BindView(R.id.about_us_btn) Button aboutUsButton;
+    @BindView(R.id.contact_us_btn) Button contactUsButton;
     @BindView(R.id.rate_us_btn) Button rateUsButton;
     @BindView(R.id.version_info) TextView version;
     @BindView(R.id.calls_to_date) TextView callsToDate;
@@ -70,6 +71,17 @@ public class AboutActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 CustomTabsUtil.launchUrl(AboutActivity.this, Uri.parse(getString(R.string.about_url)));
+            }
+        });
+
+        contactUsButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(final View view) {
+                final Intent intentChooser = Intent.createChooser(
+                        getSendEmailIntent(getResources()),
+                        getResources().getString(R.string.send_email)
+                );
+                startActivity(intentChooser);
             }
         });
 
@@ -170,5 +182,20 @@ public class AboutActivity extends AppCompatActivity {
                 .setView(view)
                 .setPositiveButton(android.R.string.ok, null)
                 .show();
+    }
+
+    /**
+     * @return an {@link Intent} that allows the user to send an email to 5 Calls
+     */
+    private static Intent getSendEmailIntent(final Resources resources) {
+        final String[] emailAddress = {resources.getString(R.string.email_address)};
+        final String subject = resources.getString(R.string.email_subject);
+
+        final Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.putExtra(Intent.EXTRA_EMAIL, emailAddress);
+        intent.putExtra(Intent.EXTRA_SUBJECT, subject);
+        intent.setType(EMAIL_CONTENT_TYPE);
+
+        return intent;
     }
 }

--- a/5calls/app/src/main/res/layout/activity_about.xml
+++ b/5calls/app/src/main/res/layout/activity_about.xml
@@ -101,6 +101,15 @@
             android:textColor="@color/colorAccent"
             />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/contact_us_prompt"
+            android:textColor="@color/colorPrimary"
+            android:textSize="@dimen/text_size_paragraph"
+            android:textStyle="bold|italic"
+        />
+
         <Button
             android:id="@+id/contact_us_btn"
             android:layout_width="wrap_content"

--- a/5calls/app/src/main/res/layout/activity_about.xml
+++ b/5calls/app/src/main/res/layout/activity_about.xml
@@ -101,6 +101,19 @@
             android:textColor="@color/colorAccent"
             />
 
+        <Button
+            android:id="@+id/contact_us_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_margin="0dp"
+            android:background="@android:color/transparent"
+            android:minHeight="@dimen/accessibility_min_size"
+            android:text="@string/contact_us_btn"
+            android:textAlignment="textStart"
+            android:textColor="@color/colorAccent"
+        />
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -76,6 +76,9 @@
     <!-- Button linking to the 5calls.org about page [CHAR_LIMIT=30] -->
     <string name="about_us_btn">about us</string>
 
+    <!-- Button that allows users to send 5 Calls an email [CHAR_LIMIT=30] -->
+    <string name="contact_us_btn">contact us</string>
+
     <!-- Button linking to the 5calls.org Play Store page to request a rating [CHAR_LIMIT=30] -->
     <string name="rate_us_btn">Rate 5 Calls</string>
 
@@ -376,5 +379,14 @@
 
     <!-- URL for the 5 Calls FAQ page [CHAR_LIMIT=NONE] -->
     <string name="faq_url" translatable="false">https://5calls.org/faq</string>
+
+    <!-- Email address to contact 5 Calls [CHAR_LIMIT=NONE] -->
+    <string name="email_address" translatable="false">make5calls@gmail.com</string>
+
+    <!-- Default subject for an email sent from the about page [CHAR_LIMIT=NONE] -->
+    <string name="email_subject">Feedback from 5 Calls Android App</string>
+
+    <!-- Name of the intent chooser for sending emails [CHAR_LIMIT=NONE] -->
+    <string name="send_email">Send Email</string>
 
 </resources>

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -76,6 +76,9 @@
     <!-- Button linking to the 5calls.org about page [CHAR_LIMIT=30] -->
     <string name="about_us_btn">about us</string>
 
+    <!-- Prompt to send 5 Calls an email [CHAR_LIMIT=100] -->
+    <string name="contact_us_prompt">Want to get in touch? Are we not covering an issue we should be?</string>
+
     <!-- Button that allows users to send 5 Calls an email [CHAR_LIMIT=30] -->
     <string name="contact_us_btn">contact us</string>
 


### PR DESCRIPTION
Begins to address: https://github.com/5calls/android/issues/60

Test Plan:
- Run the app on an Android emulator.
- Navigate to the "about page."
- Scroll down and click "contact us" button.
<img width="454" alt="screen shot 2017-08-25 at 2 12 10 pm" src="https://user-images.githubusercontent.com/8495791/29734670-689d3086-89a8-11e7-885f-cd63ce0901af.png">

- See email client selector (if 0 or > 1 email clients are installed) and select one.
- Ensure email is automatically populated with the email address "make5calls@gmail.com" and the subject line "Feedback from 5 Calls Android App".