### PR TITLE
Add a default contact reason.

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/RepCallActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/RepCallActivity.java
@@ -234,7 +234,7 @@ public class RepCallActivity extends AppCompatActivity {
         contactName.setText(contact.name);
 
         // Set the reason for contacting this rep, using default text if no reason is provided.
-        final String contactReasonText = contact.reason.isEmpty()
+        final String contactReasonText = TextUtils.isEmpty(contact.reason)
                 ? getResources().getString(R.string.contact_reason_default)
                 : contact.reason;
         contactReason.setText(contactReasonText);

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/RepCallActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/RepCallActivity.java
@@ -232,7 +232,13 @@ public class RepCallActivity extends AppCompatActivity {
     private void setupContactUi(int index, boolean expandLocalSection) {
         final Contact contact = mIssue.contacts[index];
         contactName.setText(contact.name);
-        contactReason.setText(contact.reason);
+
+        // Set the reason for contacting this rep, using default text if no reason is provided.
+        final String contactReasonText = contact.reason.isEmpty()
+                ? getResources().getString(R.string.contact_reason_default)
+                : contact.reason;
+        contactReason.setText(contactReasonText);
+
         if (!TextUtils.isEmpty(contact.photoURL)) {
             repImage.setVisibility(View.VISIBLE);
             Glide.with(getApplicationContext())

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -119,6 +119,9 @@
     <!-- Header to a section that says why the contact is someone you might call [CHAR_LIMIT=NONE] -->
     <string name="contact_reason_prompt">Why you\'re calling this office:</string>
 
+    <!-- Default text for a section that says why the contact is someone you might call [CHAR_LIMIT=NONE] -->
+    <string name="contact_reason_default">This organization is driving legislation related to the issue.</string>
+
     <!-- Shows the user how many calls remain and how many calls there are total for a particular issue [CHAR_LIMIT=50] -->
     <string name="call_count_remaining"><xliff:g id="callsLeft">%1$d</xliff:g> calls to make (<xliff:g id="callsTotal">%2$d</xliff:g> total)</string>
 


### PR DESCRIPTION
Addresses: https://github.com/5calls/android/issues/43

Test Plan:
- Run the app on an Android emulator.
- Navigate to a "rep call" screen. See reason for calling displayed as usual.
<img width="454" alt="screen shot 2017-08-25 at 3 39 25 pm" src="https://user-images.githubusercontent.com/8495791/29735401-84883156-89ad-11e7-80c6-a83e97229c59.png">

- Temporarily set `contact.reason` to `""` before setting up the UI and re-run the app. (Since I'm not sure if there are any current issues that don't have reasons specified.)
- Navigate to a "rep call" screen. See default reason: "This organization is driving legislation related to the issue."
<img width="454" alt="screen shot 2017-08-25 at 3 40 13 pm" src="https://user-images.githubusercontent.com/8495791/29735394-7dfd0c08-89ad-11e7-9d7e-54b760702ae5.png">
