### PR TITLE
Update gradle #119

### DIFF
--- a/5calls/app/build.gradle
+++ b/5calls/app/build.gradle
@@ -31,33 +31,38 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:28.0.0'
-    compile 'com.android.support:design:28.0.0'
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.volley:volley:1.1.0'
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'com.android.support:cardview-v7:28.0.0'
-    compile 'com.android.support:recyclerview-v7:28.0.0'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:support-v4:28.0.0'
-    compile 'com.android.support:customtabs:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.volley:volley:1.1.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.7.2'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.android.support:cardview-v7:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:customtabs:28.0.0'
 
-    compile 'com.jakewharton:butterknife:8.2.1'
+    // Suppressing warning for line below, because https://github.com/JakeWharton/butterknife says
+    // to use `implementation`.
+    // TODO: replace ButterKnife (now deprecated) with View binding - no need to update ButterKnife
+    //noinspection AnnotationProcessorOnCompilePath
+    implementation 'com.jakewharton:butterknife:8.2.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.2.1'
 
-    compile 'com.google.android.gms:play-services-analytics:16.0.5'
+    // TODO: don't bother updating - need to switch to AndroidX dependencies anyway
+    implementation 'com.google.android.gms:play-services-analytics:16.0.5'
 
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
     implementation 'com.jjoe64:graphview:4.2.2'
 
-    implementation 'com.onesignal:OneSignal:[3.10.3, 3.99.99]'
+    implementation 'com.onesignal:OneSignal:[3.14.0, 3.99.99]'
 
-    compile 'ru.noties:markwon:1.0.6'
+    implementation 'ru.noties:markwon:1.0.6'
     implementation 'me.saket:better-link-movement-method:2.2.0'
 
     // If you add any other open-source libraries, make sure to update assets/licenses.html

--- a/5calls/build.gradle
+++ b/5calls/build.gradle
@@ -10,9 +10,9 @@ buildscript {
         maven { url 'https://plugins.gradle.org/m2/'}
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.gms:google-services:4.1.0'
-        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.1, 0.99.99]'
+        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.7, 0.99.99]'
 
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/5calls/gradle/wrapper/gradle-wrapper.properties
+++ b/5calls/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Nov 17 16:49:30 PST 2018
+#Mon Jun 08 18:58:29 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Issue #119 

Update Gradle version and a couple libraries.

In addition to regular tests, I suggest testing OneSignal (push notifications). I tried to keep the change set small, but updating versions always carries risks.

The change from "compile" to "implementation" is because "compile" has been deprecated by Gradle.