### PR TITLE
Add social media links to the about screen

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/FiveCallsApplication.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/FiveCallsApplication.java
@@ -101,7 +101,8 @@ public class FiveCallsApplication extends Application {
         if (mTracker == null) {
             GoogleAnalytics analytics = GoogleAnalytics.getInstance(this);
             // To enable debug logging use: adb shell setprop log.tag.GAv4 DEBUG
-            mTracker = analytics.newTracker(R.xml.global_tracker);
+            mTracker = analytics.newTracker("fake");
+//            mTracker = analytics.newTracker(R.xml.global_tracker);
         }
         return mTracker;
     }

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/FiveCallsApplication.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/FiveCallsApplication.java
@@ -101,8 +101,7 @@ public class FiveCallsApplication extends Application {
         if (mTracker == null) {
             GoogleAnalytics analytics = GoogleAnalytics.getInstance(this);
             // To enable debug logging use: adb shell setprop log.tag.GAv4 DEBUG
-            mTracker = analytics.newTracker("fake");
-//            mTracker = analytics.newTracker(R.xml.global_tracker);
+            mTracker = analytics.newTracker(R.xml.global_tracker);
         }
         return mTracker;
     }

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/AboutActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/AboutActivity.java
@@ -1,10 +1,13 @@
 package org.a5calls.android.a5calls.controller;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.graphics.Paint;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -45,6 +48,9 @@ public class AboutActivity extends AppCompatActivity {
     @BindView(R.id.sign_up_newsletter_btn) Button signUpNewsletterButton;
     @BindView(R.id.about_us_btn) Button aboutUsButton;
     @BindView(R.id.contact_us_btn) Button contactUsButton;
+    @BindView(R.id.twitter_btn) TextView twitterButton;
+    @BindView(R.id.facebook_btn) TextView facebookButton;
+    @BindView(R.id.instagram_btn) TextView instagramButton;
     @BindView(R.id.rate_us_btn) Button rateUsButton;
     @BindView(R.id.version_info) TextView version;
     @BindView(R.id.calls_to_date) TextView callsToDate;
@@ -57,7 +63,7 @@ public class AboutActivity extends AppCompatActivity {
         setContentView(R.layout.activity_about);
         ButterKnife.bind(this);
 
-        getSupportActionBar().setTitle(getResources().getString(R.string.about_title));
+        getSupportActionBar().setTitle(getString(R.string.about_title));
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         signUpNewsletterButton.setOnClickListener(new View.OnClickListener() {
@@ -74,16 +80,30 @@ public class AboutActivity extends AppCompatActivity {
             }
         });
 
-        contactUsButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(final View view) {
-                final Intent intentChooser = Intent.createChooser(
-                        getSendEmailIntent(getResources()),
-                        getResources().getString(R.string.send_email)
-                );
-                startActivity(intentChooser);
-            }
-        });
+        setOpenIntentOnClick(
+                contactUsButton, getSendEmailIntent(getResources()), getString(R.string.send_email)
+        );
+
+        // Testing note: to see the Intent Chooser, install some Twitter apps other than the official Twitter
+        // app. The Intent Chooser will show browser apps and third-party Twitter apps. If the official
+        // Twitter app is installed, it will be opened directly without asking the user which app to open.
+        setOpenIntentOnClick(
+                twitterButton,
+                getActionIntent(getString(R.string.twitter_url)),
+                getString(R.string.open_social_media, getString(R.string.twitter_btn))
+        );
+
+        setOpenIntentOnClick(
+                facebookButton,
+                getActionIntent(getString(R.string.facebook_url)),
+                getString(R.string.open_social_media, getString(R.string.facebook_btn))
+        );
+
+        setOpenIntentOnClick(
+                instagramButton,
+                getActionIntent(getString(R.string.instagram_url)),
+                getString(R.string.open_social_media, getString(R.string.instagram_btn))
+        );
 
         rateUsButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -106,6 +126,8 @@ public class AboutActivity extends AppCompatActivity {
                 showOpenSourceLicenses();
             }
         });
+
+        underlineButtons();
 
         version.setText(String.format(getResources().getString(R.string.version_info),
                 BuildConfig.VERSION_NAME));
@@ -173,8 +195,27 @@ public class AboutActivity extends AppCompatActivity {
         }
     }
 
+    private void underlineButtons() {
+        underlineText(signUpNewsletterButton);
+        underlineText(aboutUsButton);
+        underlineText(contactUsButton);
+        underlineText(twitterButton);
+        underlineText(facebookButton);
+        underlineText(instagramButton);
+        underlineText(rateUsButton);
+        underlineText(licenseButton);
+    }
+
+    /**
+     * Underlines text in the given {@code TextView}.
+     */
+    private static void underlineText(final TextView textView) {
+        textView.setPaintFlags(textView.getPaintFlags()| Paint.UNDERLINE_TEXT_FLAG);
+    }
+
     // Inspired by https://www.bignerdranch.com/blog/open-source-licenses-and-android/
     private void showOpenSourceLicenses() {
+        @SuppressLint("InflateParams")
         WebView view = (WebView) LayoutInflater.from(this).inflate(R.layout.licence_view, null);
         view.loadUrl("file:///android_asset/licenses.html");
         new AlertDialog.Builder(this)
@@ -182,6 +223,24 @@ public class AboutActivity extends AppCompatActivity {
                 .setView(view)
                 .setPositiveButton(android.R.string.ok, null)
                 .show();
+    }
+
+    /**
+     * Sets the on click listener of the given {@link View} to launch the given {@link Intent}
+     * with a chooser with the given prompt.
+     */
+    private void setOpenIntentOnClick(final View view,
+                                      final Intent intent,
+                                      final String prompt) {
+        view.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(final View view) {
+                final Intent intentChooser = Intent.createChooser(
+                        intent, prompt
+                );
+                startActivity(intentChooser);
+            }
+        });
     }
 
     /**
@@ -196,6 +255,15 @@ public class AboutActivity extends AppCompatActivity {
         intent.putExtra(Intent.EXTRA_SUBJECT, subject);
         intent.setType(EMAIL_CONTENT_TYPE);
 
+        return intent;
+    }
+
+    /**
+     * @return an {@link Intent} that opens the given {@code url}
+     */
+    private static Intent getActionIntent(final String url) {
+        final Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse(url));
         return intent;
     }
 }

--- a/5calls/app/src/main/res/layout/activity_about.xml
+++ b/5calls/app/src/main/res/layout/activity_about.xml
@@ -63,6 +63,51 @@
             />
 
         <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/social_prompt"
+            android:textColor="@color/colorPrimary"
+            android:textSize="@dimen/text_size_paragraph"
+            android:textStyle="bold|italic"
+            />
+
+        <!-- Social media buttons. -->
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            >
+            <Button
+                android:id="@+id/twitter_btn"
+                style="@style/transparentBtnStyle"
+                android:layout_margin="0dp"
+                android:gravity="center"
+                android:text="@string/twitter_btn"
+                android:paddingRight="@dimen/activity_horizontal_margin"
+                />
+
+            <Button
+                android:id="@+id/facebook_btn"
+                style="@style/transparentBtnStyle"
+                android:layout_margin="0dp"
+                android:gravity="center"
+                android:text="@string/facebook_btn"
+                android:paddingLeft="@dimen/activity_horizontal_margin"
+                android:paddingRight="@dimen/activity_horizontal_margin"
+                />
+
+            <Button
+                android:id="@+id/instagram_btn"
+                style="@style/transparentBtnStyle"
+                android:layout_margin="0dp"
+                android:gravity="center"
+                android:text="@string/instagram_btn"
+                android:paddingLeft="@dimen/activity_horizontal_margin"
+                android:paddingRight="@dimen/activity_horizontal_margin"
+                />
+        </LinearLayout>
+
+        <TextView
             style="@style/aboutParagraphTextStyle"
             android:text="@string/rate_us_prompt" />
 

--- a/5calls/app/src/main/res/values-es/strings.xml
+++ b/5calls/app/src/main/res/values-es/strings.xml
@@ -451,5 +451,7 @@
 
     <!-- Date format used for stats -->
     <string name="date_format">dd/MM/yy</string>
+    <string name="social_prompt">Comunícate con nosotros a través de nuestras redes sociales</string>
+    <string name="open_social_media">Abre <xliff:g id="socialNetworkName">%1$s</xliff:g></string>
 
 </resources>

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -70,6 +70,18 @@
     <!-- Button that allows users to send 5 Calls an email [CHAR_LIMIT=30] -->
     <string name="contact_us_btn">contact us</string>
 
+    <!-- Prompt to connect with 5 Calls through social media [CHAR_LIMIT=100] -->
+    <string name="social_prompt">You can also get in touch via</string>
+
+    <!-- Button that links to 5 Calls' Twitter -->
+    <string name="twitter_btn" translatable="false">Twitter</string>
+
+    <!-- Button that links to 5 Calls' Facebook [CHAR_LIMIT=30] -->
+    <string name="facebook_btn" translatable="false">Facebook</string>
+
+    <!-- Button that links to 5 Calls' Instagram [CHAR_LIMIT=30] -->
+    <string name="instagram_btn" translatable="false">Instagram</string>
+
     <!-- Button linking to the 5calls.org Play Store page to request a rating [CHAR_LIMIT=30] -->
     <string name="rate_us_btn">Rate 5 Calls</string>
 
@@ -380,6 +392,15 @@
     <!-- Action for a snackbar or button which brings you to the location update screen [CHAR_LIMIT=10] -->
     <string name="update">update</string>
 
+    <!-- URL for the 5 Calls Twitter account -->
+    <string name="twitter_url" translatable="false">https://twitter.com/make5calls</string>
+
+    <!-- URL for the 5 Calls Facebook page -->
+    <string name="facebook_url" translatable="false">https://www.facebook.com/make5calls/</string>
+
+    <!-- URL for the 5 Calls Instagram account -->
+    <string name="instagram_url" translatable="false">https://www.instagram.com/5calls/</string>
+
     <!-- URL to sign up for the 5 Calls newsletter [CHAR_LIMIT=NONE] -->
     <string name="newsletter_url" translatable="false">https://5calls.org/newsletter</string>
 
@@ -397,6 +418,11 @@
 
     <!-- Name of the intent chooser for sending emails [CHAR_LIMIT=NONE] -->
     <string name="send_email">Send Email</string>
+
+    <!-- Name of the intent chooser for opening Twitter/Facebook/Instagram [CHAR_LIMIT=NONE]
+    Instead of having three separate strings for "Open Twitter", "Open Facebook", "Open Instagram",
+    we can use one substitution string and substitute the social network name that we use in the buttons -->
+    <string name="open_social_media">Open <xliff:g id="socialNetworkName">%1$s</xliff:g></string>
 
     <!-- Call result button for when the contact was unavailable (i.e. couldn't even leave a voicemail) [CHAR_LIMIT=30] -->
     <string name="outcome_unavailable">unavailable</string>


### PR DESCRIPTION
Addresses: #60

Replacement for PR #96 

I tried to stay faithful to the original changeset from @hblumberg, including the suggested changes by @dektar, plus a few more small tweaks.

Normally I try to fix every warning in every file I change - but I think that may not make sense for this codebase. Once the app is changed over to AndroidX, Kotlin, using ConstraintLayouts, etc., many of the existing warnings will no longer be relevant.

I asked a Spanish-speaking friend for the translations.

I personally don't feel the "CHAR_LIMIT" comments are needed in strings.xml. That isn't an official part of Android development, and isn't a common practice - apparently it's meant to be an indication to either the translator ("the UI only has space for 17 characters here") or for the developer ("translations of this text can go up for 47 characters, so make sure. you build a UI that can accommodate that"). I feel developers should focus on making a flexible UI that can accommodate varying text lengths and sizes, so these CHAR_LIMIT comments aren't necessarily helpful. But for now they're entrenched in the app, so I'll leave them for consistency's sake. Perhaps someday in the future we'll remove them.

Note to @nickoneill: this PR changes the appearance of most of the links on the About screen, so that the red all-caps links will now have an underline. The GitHub link will continue to be blue, lowercase and underlined. Also, if this PR is accepted, PR #96 can be closed.

Screenshot after change:
![device-2020-06-18-103950](https://user-images.githubusercontent.com/1164989/85041939-356c2000-b150-11ea-9954-065b78d1e5b7.png)
