### PR TITLE
Optional user name script replacement

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/RepCallActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/RepCallActivity.java
@@ -34,6 +34,7 @@ import com.bumptech.glide.Glide;
 import org.a5calls.android.a5calls.AppSingleton;
 import org.a5calls.android.a5calls.R;
 import org.a5calls.android.a5calls.adapter.OutcomeAdapter;
+import org.a5calls.android.a5calls.model.AccountManager;
 import org.a5calls.android.a5calls.model.Contact;
 import org.a5calls.android.a5calls.model.Issue;
 import org.a5calls.android.a5calls.model.Outcome;
@@ -139,7 +140,13 @@ public class RepCallActivity extends AppCompatActivity {
         scrollView.setDescendantFocusability(ViewGroup.FOCUS_BEFORE_DESCENDANTS);
 
         Contact c = mIssue.contacts.get(mActiveContactIndex);
-        String script = ScriptReplacements.replacing(this, mIssue.script, c, getIntent().getStringExtra(KEY_LOCATION_NAME));
+        String script = ScriptReplacements.replacing(
+                this,
+                mIssue.script,
+                c,
+                getIntent().getStringExtra(KEY_LOCATION_NAME),
+                AccountManager.Instance.getUserName(this)
+        );
         MarkdownUtil.setUpScript(callScript, script, getApplicationContext());
 
         boolean expandLocalOffices = false;

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/SettingsActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/SettingsActivity.java
@@ -180,6 +180,14 @@ public class SettingsActivity extends AppCompatActivity {
                         AccountManager.DEFAULT_NOTIFICATION_SELECTION);
                 updateNotificationsPreference((FiveCallsApplication) getActivity().getApplication(),
                         accountManager, result);
+            } else if (TextUtils.equals(key, AccountManager.KEY_USER_NAME)) {
+                String result = sharedPreferences.getString(key, null);
+                if (result != null) {
+                    result = result.trim();
+                    AccountManager.Instance.setUserName(getActivity(), result);
+                } else {
+                    AccountManager.Instance.setUserName(getActivity(), null);
+                }
             }
         }
 

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/model/AccountManager.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/model/AccountManager.java
@@ -37,6 +37,7 @@ public enum AccountManager {
     private static final String KEY_LOCATION_NAME = "prefsKeyLocationName";
     private static final String KEY_NEWSLETTER_PROMPT_DONE = "prefsKeyNewsletterPrompt";
     private static final String KEY_NEWSLETTER_SIGNUP_DONE = "prefsKeyNewsletterSignup";
+    public static final String KEY_USER_NAME = "prefsKeyUserName";
 
     // Default to 11 am.
     public static final int DEFAULT_REMINDER_MINUTES = 60 * 11;
@@ -188,6 +189,14 @@ public enum AccountManager {
 
     public void setReviewDialogShown(Context context, boolean shown) {
         getSharedPrefs(context).edit().putBoolean(KEY_REVIEW_DIALOG_SHOWN, shown).apply();
+    }
+
+    public String getUserName(Context context) {
+        return getSharedPrefs(context).getString(KEY_USER_NAME, null);
+    }
+
+    public void setUserName(Context context, String userName) {
+        getSharedPrefs(context).edit().putString(KEY_USER_NAME, userName).apply();
     }
 
     private SharedPreferences getSharedPrefs(Context context) {

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/util/ScriptReplacements.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/util/ScriptReplacements.java
@@ -15,6 +15,7 @@ public class ScriptReplacements {
     private static final Pattern SENATE_INTRO_PATTERN = Pattern.compile("\\*{2}WHEN CALLING SENATE:\\*{2}\\n");
     private static final Pattern CONTACT_NAME_PATTERN = Pattern.compile("\\[REP/SEN NAME]|\\[SENATOR/REP NAME]|\\[SENATOR NAME]|\\[REPRESENTATIVE NAME]");
     private static final Pattern LOCATION_PATTERN = Pattern.compile("\\[CITY,\\s?ZIP]|\\[CITY,\\s?STATE]");
+    private static final Pattern NAME_PATTERN = Pattern.compile("\\[NAME]");
 
     private static final String US_HOUSE = "US House";
     private static final String HOUSE = "House";
@@ -26,12 +27,16 @@ public class ScriptReplacements {
     private static final String ATTORNEY_GENERAL = "AttorneyGeneral";
     private static final String SECRETARY_OF_STATE = "SecretaryOfState";
 
-    public static String replacing(Context context, String script, Contact contact, @Nullable String location) {
+    public static String replacing(Context context, String script, Contact contact, @Nullable String location, @Nullable String userName) {
         String replacedScript = chooseSubscript(script, contact);
         replacedScript = replacingContact(context, script, contact);
 
         if (!TextUtils.isEmpty(location)) {
             replacedScript = replacingLocation(replacedScript, location);
+        }
+
+        if (!TextUtils.isEmpty(userName)) {
+            replacedScript = replacingUserName(replacedScript, userName);
         }
 
         return replacedScript;
@@ -60,6 +65,10 @@ public class ScriptReplacements {
 
     private static String replacingLocation(String script, String location) {
         return LOCATION_PATTERN.matcher(script).replaceAll(location);
+    }
+
+    private static String replacingUserName(String script, String userName) {
+        return NAME_PATTERN.matcher(script).replaceAll(userName);
     }
 
     private static Pattern wholeRegex(Pattern introPattern) {

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/util/ScriptReplacements.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/util/ScriptReplacements.java
@@ -15,7 +15,7 @@ public class ScriptReplacements {
     private static final Pattern SENATE_INTRO_PATTERN = Pattern.compile("\\*{2}WHEN CALLING SENATE:\\*{2}\\n");
     private static final Pattern CONTACT_NAME_PATTERN = Pattern.compile("\\[REP/SEN NAME]|\\[SENATOR/REP NAME]|\\[SENATOR NAME]|\\[REPRESENTATIVE NAME]");
     private static final Pattern LOCATION_PATTERN = Pattern.compile("\\[CITY,\\s?ZIP]|\\[CITY,\\s?STATE]");
-    private static final Pattern NAME_PATTERN = Pattern.compile("\\[NAME]");
+    private static final Pattern NAME_PATTERN = Pattern.compile("\\[\\s*NAME\\s*]", Pattern.CASE_INSENSITIVE);
 
     private static final String US_HOUSE = "US House";
     private static final String HOUSE = "House";

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -561,4 +561,9 @@
     <!-- Snackbar error shown when the newsletter subscription request failed. -->
     <string name="newsletter_signup_error">There was an error subscribing you to the newsletter. Please try again later.</string>
 
+    <!-- Title for user's name preference -->
+    <string name="settings_name">Name</string>
+
+    <!-- Description for the name preference -->
+    <string name="settings_name_description">Set your name for auto-formatting call scripts.</string>
 </resources>

--- a/5calls/app/src/main/res/xml/settings.xml
+++ b/5calls/app/src/main/res/xml/settings.xml
@@ -48,6 +48,12 @@
         android:title="@string/settings_category_general"
         >
 
+        <EditTextPreference
+            android:key="prefsKeyUserName"
+            android:singleLine="true"
+            android:summary="@string/settings_name_description"
+            android:title="@string/settings_name" />
+
         <SwitchPreference
             android:title="@string/setting_usage_title"
             android:defaultValue="true"

--- a/5calls/app/src/main/res/xml/settings.xml
+++ b/5calls/app/src/main/res/xml/settings.xml
@@ -52,7 +52,8 @@
             android:key="prefsKeyUserName"
             android:singleLine="true"
             android:summary="@string/settings_name_description"
-            android:title="@string/settings_name" />
+            android:title="@string/settings_name"
+            />
 
         <SwitchPreference
             android:title="@string/setting_usage_title"


### PR DESCRIPTION
#143 

Added an EditTextPreference so the user can add their name for the call script. Trims whitespace from start and end of entered String. Setting an empty value will clear the preference.

Added a new Regex matcher for the [NAME] text in the script. Preserves the bold markdown formatting.