### PR TITLE
Handle notification permission revoked more gracefully in settings activity UI

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/FiveCallsApplication.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/FiveCallsApplication.java
@@ -18,13 +18,18 @@ package org.a5calls.android.a5calls;
 
 import android.app.Activity;
 import android.app.Application;
+import android.app.NotificationManager;
 import android.os.Bundle;
+import android.util.Log;
+
+import androidx.core.app.NotificationManagerCompat;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.auth.FirebaseAuth;
 
 import com.onesignal.OneSignal;
 
+import org.a5calls.android.a5calls.controller.SettingsActivity;
 import org.a5calls.android.a5calls.model.AccountManager;
 import org.a5calls.android.a5calls.model.NotificationUtils;
 
@@ -103,6 +108,16 @@ public class FiveCallsApplication extends Application {
             String uuid = UUID.randomUUID().toString();
             AccountManager.Instance.setCallerID(this, uuid);
             OneSignal.setExternalUserId(uuid);
+        }
+
+        // Check if notification permission has been revoked outside of the app since the last run
+        if (!NotificationManagerCompat.from(this).areNotificationsEnabled()) {
+            // Reset the notifications preference
+            SettingsActivity.updateNotificationsPreference(
+                    this,
+                    AccountManager.Instance,
+                    AccountManager.DEFAULT_NOTIFICATION_SELECTION
+            );
         }
     }
 

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/SettingsActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/SettingsActivity.java
@@ -102,7 +102,7 @@ public class SettingsActivity extends AppCompatActivity {
         accountManager.setNotificationPreference(application, result);
         if (TextUtils.equals("0", result)) {
             OneSignal.disablePush(false);
-            OneSignal.promptForPushNotifications();
+            OneSignal.promptForPushNotifications(true);
         } else if (TextUtils.equals("1", result)) {
             OneSignal.disablePush(true);
         }


### PR DESCRIPTION
Fixes #139 

Added a notification permission check in the onCreate of FiveCallsApplication, if it is not granted it sets the notificationPreference to the default value.

Added a parameter in the OneSignal promptForPushNotification method that will promp the user to open system settings if the notification permission is denied and the system prompt can no longer be used

![photo_2025-02-09_05-10-09](https://github.com/user-attachments/assets/ea5a3104-3fb8-494e-846e-3aaf9629ec30)