### PR TITLE
Update markwon and allow strikethrough with ~ or ~~

### DIFF
--- a/5calls/app/build.gradle
+++ b/5calls/app/build.gradle
@@ -76,8 +76,9 @@ dependencies {
 
     implementation 'com.onesignal:OneSignal:[4.8.6, 4.99.99]'
 
-    implementation 'ru.noties:markwon:1.0.6'
-    implementation 'me.saket:better-link-movement-method:2.2.0'
+    implementation 'io.noties.markwon:core:4.6.2'
+    implementation 'io.noties.markwon:ext-strikethrough:4.6.2'
+    implementation 'io.noties.markwon:simple-ext:4.6.2'
 
     implementation 'com.wbrawner.plausible:plausible-android:0.1.0-SNAPSHOT'
 

--- a/5calls/app/src/main/assets/licenses.html
+++ b/5calls/app/src/main/assets/licenses.html
@@ -55,12 +55,6 @@
         <p>Dimitry Ivanov</p>
     </li>
     <li>
-        <b>Better-Link-Movement-Method</b>
-        <br/>
-        <p>Copyright 2018</p>
-        <p>Saket Narayan</p>
-    </li>
-    <li>
         <b>GraphView</b>
         <br/>
         <p>Copyright 2016</p>

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/util/MarkdownUtil.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/util/MarkdownUtil.java
@@ -1,54 +1,36 @@
 package org.a5calls.android.a5calls.util;
 
 import android.content.Context;
+import android.text.style.StrikethroughSpan;
 import android.widget.TextView;
 
-import org.commonmark.node.Node;
-import org.commonmark.parser.Parser;
+import androidx.annotation.NonNull;
+import io.noties.markwon.Markwon;
+import io.noties.markwon.MarkwonConfiguration;
+import io.noties.markwon.RenderProps;
+import io.noties.markwon.SpanFactory;
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
+import io.noties.markwon.simple.ext.SimpleExtPlugin;
 
-import me.saket.bettermovementmethod.BetterLinkMovementMethod;
-import ru.noties.markwon.Markwon;
-import ru.noties.markwon.SpannableConfiguration;
-import ru.noties.markwon.renderer.SpannableRenderer;
-
-/**
- * Shim to get around LinkMovementMethod while using Markwon.
- */
 public class MarkdownUtil {
     /**
-     * Temporary work-around for Markwon.setMarkdown(view, script); while LinkMovementMethod
-     * crashes during selection.
-     * See https://github.com/noties/Markwon/issues/41
-     * and https://github.com/noties/Markwon/tree/v1.0.6#quick-start.
+     * Set up markwon with strikethrough using ~ or ~~.
      */
-    public static void setUpScript(TextView view, String script, Context context) {
-        // create a Parser instance (can be done manually)
-        // internally creates default Parser instance & registers `strike-through` & `tables` extension
-        final Parser parser = Markwon.createParser();
-
-        // core class to display markdown, can be obtained via this method,
-        // which creates default instance (no images handling though),
-        // or via `builder` method, which lets you to configure this instance
-        //
-        // `this` refers to a Context instance
-        final SpannableConfiguration configuration = SpannableConfiguration.create(context);
-
-        // it's better **not** to re-use this class between multiple calls
-        final SpannableRenderer renderer = new SpannableRenderer();
-
-        final Node node = parser.parse(script);
-        final CharSequence text = renderer.render(configuration, node);
-
-        // for links in markdown to be clickable
-        view.setMovementMethod(BetterLinkMovementMethod.getInstance());
-
-        // we need these due to the limited nature of Spannables to invalidate TextView
-        Markwon.unscheduleDrawables(view);
-        Markwon.unscheduleTableRows(view);
-
-        view.setText(text);
-
-        Markwon.scheduleDrawables(view);
-        Markwon.scheduleTableRows(view);
+    public static void setUpScript(TextView view, String text, Context context) {
+        final Markwon markwon = Markwon.builder(context)
+                // Strikethrough with ~~
+                .usePlugin(StrikethroughPlugin.create())
+                // Strikethrough with ~
+                .usePlugin(SimpleExtPlugin.create(plugin -> plugin
+                        .addExtension(1, '~', new SpanFactory() {
+                            @Override
+                            public Object getSpans(
+                                    @NonNull MarkwonConfiguration configuration,
+                                    @NonNull RenderProps props) {
+                                return new StrikethroughSpan();
+                            }
+                        })))
+                .build();
+        markwon.setMarkdown(view, text);
     }
 }


### PR DESCRIPTION
Fixes #177. No longer need link movement method because links work fine in updated markwon.

Test: Checked links, bold, strikethrough, and blockquote manually.