### PR TITLE
Update expected values for IssuesAdapterTest

### DIFF
--- a/5calls/app/src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java
+++ b/5calls/app/src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java
@@ -37,7 +37,7 @@ public class IssuesAdapterTest {
         Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
         List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("Healthcare", issues);
-        assertEquals(3, filtered.size());
+        assertEquals(4, filtered.size());
     }
 
     @Test
@@ -46,7 +46,7 @@ public class IssuesAdapterTest {
         Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
         List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("hEaLtHcArE", issues);
-        assertEquals(3, filtered.size());
+        assertEquals(4, filtered.size());
     }
 
     @Test
@@ -73,7 +73,7 @@ public class IssuesAdapterTest {
         Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
         List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("Trump admin", issues);
-        assertEquals(2, filtered.size());
+        assertEquals(4, filtered.size());
     }
 
     @Test


### PR DESCRIPTION
After #192 added searching the issue reason instead of just the title and category the expected values for some tests changed causing three tests in IssuesAdapterTest to fail