### PR TITLE
Speculative fix for OneSignal crash, #224

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/net/FiveCallsApi.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/net/FiveCallsApi.java
@@ -212,7 +212,9 @@ public class FiveCallsApi {
                             String state = response.getString("state");
                             String district = response.getString("district");
                             if (!TextUtils.isEmpty(state) && !TextUtils.isEmpty(district)) {
-                                OneSignal.getUser().addTag("districtID", state + "-" + district);
+                                if (OneSignal.isInitialized()) {
+                                    OneSignal.getUser().addTag("districtID", state + "-" + district);
+                                }
                             }
                         } catch (JSONException e) {
                             e.printStackTrace();


### PR DESCRIPTION
Hopefully checking for initialized will ensure we don't call `OneSignal.getUser` before `initWithContext`. The crash is infrequent and missing the user tag seems fine in these cases.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization

## Description

Recent changes caused an infrequent OneSignal crash starting in V64 and continuing through V66. This should help.

## Related Issues
- Closes #224

## Were the changes tested?

- [ ] Yes, automated tests in _please name test methods or files_
- [ ] Yes, manually tested: _please provide steps performed to test changes_
- [x] No, and this is why: cannot reproduce test locally. Did test that it builds/runs normally.
- [ ] I need help with writing tests
