### PR TITLE
Re-enable abortOnError for lint after fix

### DIFF
--- a/5calls/app/build.gradle
+++ b/5calls/app/build.gradle
@@ -23,7 +23,6 @@ android {
     }
     namespace 'org.a5calls.android.a5calls'
     lint {
-        abortOnError false // Temporary until build errors are resolved, see issue #208
     }
 
     compileOptions {

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/SingleLineResizableTextView.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/SingleLineResizableTextView.java
@@ -16,13 +16,13 @@
 
 package org.a5calls.android.a5calls.controller;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.TypedValue;
-import android.widget.TextView;
+
+import androidx.appcompat.widget.AppCompatTextView;
 
 import org.a5calls.android.a5calls.R;
 
@@ -36,7 +36,7 @@ import org.a5calls.android.a5calls.R;
  * totally different should be displayed in it.
  * This is from https://github.com/google/science-journal/blob/master/OpenScienceJournal/whistlepunk_library/src/main/java/com/google/android/apps/forscience/whistlepunk/SingleLineResizableTextView.java.
  */
-public class SingleLineResizableTextView extends TextView {
+public class SingleLineResizableTextView extends AppCompatTextView {
 
     private static final String TAG = "ResizableTextView";
 
@@ -58,13 +58,6 @@ public class SingleLineResizableTextView extends TextView {
 
     public SingleLineResizableTextView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        init();
-    }
-
-    @TargetApi(21)
-    public SingleLineResizableTextView(Context context, AttributeSet attrs, int defStyleAttr,
-                                       int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
         init();
     }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization

## Description
This is a minimal fix that only addresses the site marked by lint as an error. Notably, this PR does not address any sites marked by lint with warnings, as lint does not stop the build when only warning sites are detected

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #208

## Were the changes tested?
- [x] Yes, manually tested:
As far as I can tell, the modified Java class, [`SingleLineResizableTextView.java`](https://github.com/5calls/android/compare/master...LogosOfJ:5calls-android:208-resolve-lint-errors?expand=1#diff-6ccc294085f41f309b36d77a19ff56df6f595be5355563cdf78fb6649a1e6846), is only used by the Representative Call activity (`activity_rep_call.xml`); I did not observe any problems when manually testing that page on the app in the Android Studio emulator or on my personal Android device (Pixel 7a).

- [x] I need help with writing tests
I am not familiar with how to write manual test procedures or automated GUI tests for this project.