### PR TITLE
244 regex exception during filtering

### DIFF
--- a/5calls/app/src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java
+++ b/5calls/app/src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java
@@ -123,6 +123,21 @@ public class IssuesAdapterTest {
         }
     ]""";
 
+    /**
+     * 2025-07-19 XXX: this test is a companion to
+     * {@link #testFilterIssuesBySearchText_matchesReason_doesNotMatchIfNotStartOfWord()}
+     * that demonstrates that different criteria are used for matching
+     * searchText against titles and reasons.
+     */
+    @Test
+    public void testFilterIssuesBySearchText_matchesTitle_doesMatchEndOfWord() {
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
+        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("over", issues);
+        assertEquals(1, filtered.size());
+    }
+
     @Test
     public void testFilterIssuesBySearchText_matchesReason_matchesStartOfFirstWord() {
         Gson gson = new GsonBuilder().serializeNulls().create();
@@ -133,12 +148,26 @@ public class IssuesAdapterTest {
     }
 
     @Test
+    public void testFilterIssuesBySearchText_matchesReason_matchesWordPrefixes() {
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
+        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("Press Conf", issues);
+        assertEquals(1, filtered.size());
+    }
+
+    @Test
     public void testFilterIssuesBySearchText_matchesReason_noCrashIfSearchTextIsInvalidRegex() {
         Gson gson = new GsonBuilder().serializeNulls().create();
         Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
         List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("[", issues);
         assertEquals(0, filtered.size());
+        String regexQuotePattern = "\\E[";
+        List<Issue> secondFilterAttempt = IssuesAdapter.filterIssuesBySearchText(
+            regexQuotePattern, issues
+        );
+        assertEquals(0, secondFilterAttempt.size());
     }
 
     @Test

--- a/5calls/app/src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java
+++ b/5calls/app/src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(AndroidJUnit4.class)
 public class IssuesAdapterTest {
+
     @Test
     public void testFilterIssuesBySearchText_noMatches() {
         Gson gson = new GsonBuilder().serializeNulls().create();
@@ -93,6 +94,59 @@ public class IssuesAdapterTest {
         Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
         List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("isplacement", issues);
+        assertEquals(0, filtered.size());
+    }
+
+    private static final String REGEX_TEST_ISSUE_DATA = """
+    [
+        {
+            "id": 35700,
+            "createdAt": "2025-02-05T18:01:44Z",
+            "name": "Condemn a US Takeover of Gaza",
+            "reason": "During a press conference alongside,",
+            "script": "Hi, my name is **[NAME]** and ... from [].\\n\\n",
+            "categories": [{"name": "Foreign Affairs"}],
+            "contactType": "REPS",
+            "contacts": null,
+            "contactAreas": ["US House","US Senate"],
+            "outcomeModels": [
+                {"label": "unavailable","status": "unavailable"},
+                {"label": "voicemail","status": "voicemail"},
+                {"label": "contact","status": "contact"},
+                {"label": "skip","status": "skip"}
+            ],
+            "stats": { "calls": 0 },
+            "slug": "trump-us-gaza-palestinian-occupation",
+            "active": true,
+            "hidden": false,
+            "meta": ""
+        }
+    ]""";
+
+    @Test
+    public void testFilterIssuesBySearchText_matchesReason_matchesStartOfFirstWord() {
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
+        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("During", issues);
+        assertEquals(1, filtered.size());
+    }
+
+    @Test
+    public void testFilterIssuesBySearchText_matchesReason_noCrashIfSearchTextIsInvalidRegex() {
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
+        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("[", issues);
+        assertEquals(0, filtered.size());
+    }
+
+    @Test
+    public void testFilterIssuesBySearchText_matchesReason_searchTextNotInterpretedAsRegexPattern() {
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
+        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText(".", issues);
         assertEquals(0, filtered.size());
     }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
This PR is focused on preventing the crash described in #244, which occurs when the user-provided `searchText` is interpreted as invalid regex when `IssuesAdapter` attempts to search issue reasons.

Additional concerns:
- Behavior change made in this PR: the regex was modified to change edge case behavior when `searchText` only matches a prefix of the first word in a reason: old behavior would not match the issue while new behavior does. This change brings the behavior in line with the stated intent of the comment: "Search through the issue's reason for words that start with the search text"
- Potentially undesirable behavior not changed in this PR: `searchText` matches the text of reason before it is interpreted as markdown. This means that some searches may match parts of links that are not visible to end users. For example, the reason
  ```
  [a link](http://example.com)
  ```
  will be matched by `searchText := "("` even though no `(` characters are visible the rendered text
  > [a link](http://example.com)

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #244

## Were the changes tested?

- [x] Yes, automated tests in `IssuesAdapterTest.java` (`src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java`)
- [x] Yes, manually tested: I verified the search text `[`  triggered #244 on builds of commit af9b67eb0b62502c7c4ac97db3a2be653da2a37f (the tip of `master` as of 2025-08-01) installed on Android emulators and that the crash is not triggered on builds of commit f83cf918aefdd27df9c73f9ebc4a17c72b8f790f.

