### PR TITLE
Select a dialer app when more than one installed

### DIFF
--- a/5calls/app/src/main/AndroidManifest.xml
+++ b/5calls/app/src/main/AndroidManifest.xml
@@ -94,11 +94,15 @@
         </provider>
     </application>
 
-    <!-- Query for Android 11+ to find apps that can handle mailto Intents -->
+    <!-- Query for Android 11+ to find apps that can handle mailto and tel Intents -->
     <queries>
         <intent>
             <action android:name="android.intent.action.SENDTO"/>
             <data android:scheme="mailto" android:host="*" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.DIAL"/>
+            <data android:scheme="tel" />
         </intent>
     </queries>
 

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/RepCallActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/RepCallActivity.java
@@ -23,6 +23,9 @@ import androidx.recyclerview.widget.GridLayoutManager;
 
 import android.text.TextUtils;
 import android.text.util.Linkify;
+import android.text.style.UnderlineSpan;
+import android.text.SpannableString;
+import android.graphics.Paint;
 import android.util.DisplayMetrics;
 import android.util.Patterns;
 import android.view.LayoutInflater;
@@ -30,6 +33,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 
@@ -396,10 +400,27 @@ public class RepCallActivity extends AppCompatActivity {
         return (int) (displayMetrics.widthPixels / minButtonWidth);
     }
 
-    private static void linkPhoneNumber(TextView textView, String phoneNumber) {
-        textView.setText(phoneNumber);
-        Linkify.addLinks(textView, Patterns.PHONE, "tel:",
-                Linkify.sPhoneNumberMatchFilter,
-                Linkify.sPhoneNumberTransformFilter);
+    private void linkPhoneNumber(TextView textView, String phoneNumber) {
+        SpannableString spannableString = new SpannableString(phoneNumber);
+        spannableString.setSpan(new UnderlineSpan(), 0, phoneNumber.length(), 0);
+        textView.setText(spannableString);
+        textView.setClickable(true);
+        textView.setFocusable(true);
+        textView.setTextColor(getResources().getColor(R.color.colorAccent, null));
+        textView.setOnClickListener(v -> {
+            Intent dialIntent = new Intent(Intent.ACTION_DIAL);
+            dialIntent.setData(android.net.Uri.parse("tel:" + phoneNumber));
+            
+            try {
+                Intent chooser = Intent.createChooser(dialIntent, "Choose phone app");
+                startActivity(chooser);
+            } catch (android.content.ActivityNotFoundException e) {
+                try {
+                    startActivity(dialIntent);
+                } catch (android.content.ActivityNotFoundException e2) {
+                    Toast.makeText(this, "No phone app available to make calls", Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

Android has other apps that can act as phone dialers, when multiple are installed we should give the user the option of which to use. Draft until I clean up some of the strings and such.

## Were the changes tested?

- [ ] Yes, automated tests in _please name test methods or files_
- [x] Yes, manually tested: tested with multiple dial intent apps installed and with only one, and with none.
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
