### PR TITLE
Location accuracy warning for state reps

### DIFF
--- a/5calls/app/src/androidTest/java/org/a5calls/android/a5calls/net/FiveCallsApiTest.java
+++ b/5calls/app/src/androidTest/java/org/a5calls/android/a5calls/net/FiveCallsApiTest.java
@@ -106,10 +106,10 @@ public class FiveCallsApiTest {
 
         @Override
         public void onContactsReceived(String locationName, String districtId,
-                                       boolean isDistrictSplit, List<Contact> contacts, boolean stateChanged) {
+                                       boolean isDistrictSplit, boolean isLowAccuracy, List<Contact> contacts, boolean stateChanged) {
             mLocationName = locationName;
             mDistrictId = districtId;
-            mIsDistrictSplit = isDistrictSplit;
+            mIsDistrictSplit = isDistrictSplit || isLowAccuracy;
             mContacts = contacts;
         }
     }

--- a/5calls/app/src/androidTest/java/org/a5calls/android/a5calls/net/FiveCallsApiTest.java
+++ b/5calls/app/src/androidTest/java/org/a5calls/android/a5calls/net/FiveCallsApiTest.java
@@ -85,7 +85,7 @@ public class FiveCallsApiTest {
         protected int mContactsJsonError = 0;
         protected int mAddressError = 0;
         protected List<Contact> mContacts = null;
-        protected boolean mLowAccuracy = false;
+        protected boolean mIsDistrictSplit = false;
         protected String mLocationName = null;
         protected String mDistrictId = null;
 
@@ -106,10 +106,10 @@ public class FiveCallsApiTest {
 
         @Override
         public void onContactsReceived(String locationName, String districtId,
-                                       boolean isLowAccuracy, List<Contact> contacts, boolean stateChanged) {
+                                       boolean isDistrictSplit, List<Contact> contacts, boolean stateChanged) {
             mLocationName = locationName;
             mDistrictId = districtId;
-            mLowAccuracy = isLowAccuracy;
+            mIsDistrictSplit = isDistrictSplit;
             mContacts = contacts;
         }
     }
@@ -309,7 +309,7 @@ public class FiveCallsApiTest {
         assertEquals(0, testContactsListener.mContactsError);
         assertEquals(0, testContactsListener.mAddressError);
         assertEquals(0, testContactsListener.mContactsJsonError);
-        assertTrue(testContactsListener.mLowAccuracy);
+        assertTrue(testContactsListener.mIsDistrictSplit);
 
     }
 

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
@@ -84,7 +84,9 @@ public class IssueActivity extends AppCompatActivity {
     private boolean mShowServerError = false;
 
     private Issue mIssue;
+    // indicates that the zip entered intersects with multiple congressional districts
     private boolean mIsDistrictSplit = false;
+    // low accuracy locations are zip codes or city names, we warn on state reps if you are using one
     private boolean mIsLowAccuracy = false;
     private boolean mDonateIsOn = false;
     private boolean mIsAnimating = false;
@@ -465,7 +467,7 @@ public class IssueActivity extends AppCompatActivity {
             contactReason.setText(contact.reason);
             if (TextUtils.equals(contact.area, Contact.AREA_HOUSE) && mIsDistrictSplit) {
                 contactWarning.setVisibility(View.VISIBLE);
-                contactWarning.setText(R.string.low_accuracy_warning);
+                contactWarning.setText(R.string.split_district_warning);
             } else if ((TextUtils.equals(contact.area, Contact.AREA_STATE_LOWER) ||
                        TextUtils.equals(contact.area, Contact.AREA_STATE_UPPER)) && mIsLowAccuracy) {
                 contactWarning.setVisibility(View.VISIBLE);

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
@@ -69,6 +69,7 @@ public class IssueActivity extends AppCompatActivity {
     private static final String TAG = "IssueActivity";
     public static final String KEY_ISSUE = "key_issue";
     public static final String KEY_IS_DISTRICT_SPLIT = "key_is_district_split";
+    public static final String KEY_IS_LOW_ACCURACY = "key_is_low_accuracy";
     public static final String KEY_DONATE_IS_ON = "key_donate_is_on";
 
     public static final int RESULT_OK = 1;
@@ -84,6 +85,7 @@ public class IssueActivity extends AppCompatActivity {
 
     private Issue mIssue;
     private boolean mIsDistrictSplit = false;
+    private boolean mIsLowAccuracy = false;
     private boolean mDonateIsOn = false;
     private boolean mIsAnimating = false;
 
@@ -102,6 +104,7 @@ public class IssueActivity extends AppCompatActivity {
             return;
         }
         mIsDistrictSplit = getIntent().getBooleanExtra(KEY_IS_DISTRICT_SPLIT, false);
+        mIsLowAccuracy = getIntent().getBooleanExtra(KEY_IS_LOW_ACCURACY, false);
         mDonateIsOn = getIntent().getBooleanExtra(KEY_DONATE_IS_ON, false);
 
         setContentView(binding.getRoot());
@@ -245,6 +248,7 @@ public class IssueActivity extends AppCompatActivity {
         super.onSaveInstanceState(outState);
         outState.putParcelable(KEY_ISSUE, mIssue);
         outState.putBoolean(KEY_IS_DISTRICT_SPLIT, mIsDistrictSplit);
+        outState.putBoolean(KEY_IS_LOW_ACCURACY, mIsLowAccuracy);
     }
 
     @Override
@@ -462,6 +466,10 @@ public class IssueActivity extends AppCompatActivity {
             if (TextUtils.equals(contact.area, Contact.AREA_HOUSE) && mIsDistrictSplit) {
                 contactWarning.setVisibility(View.VISIBLE);
                 contactWarning.setText(R.string.low_accuracy_warning);
+            } else if ((TextUtils.equals(contact.area, Contact.AREA_STATE_LOWER) ||
+                       TextUtils.equals(contact.area, Contact.AREA_STATE_UPPER)) && mIsLowAccuracy) {
+                contactWarning.setVisibility(View.VISIBLE);
+                contactWarning.setText(R.string.low_accuracy_state_rep_warning);
             }
             contactReason.setVisibility(View.VISIBLE);
         } else {

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
@@ -68,7 +68,7 @@ import java.util.TimeZone;
 public class IssueActivity extends AppCompatActivity {
     private static final String TAG = "IssueActivity";
     public static final String KEY_ISSUE = "key_issue";
-    public static final String KEY_IS_LOW_ACCURACY = "key_is_low_accuracy";
+    public static final String KEY_IS_DISTRICT_SPLIT = "key_is_district_split";
     public static final String KEY_DONATE_IS_ON = "key_donate_is_on";
 
     public static final int RESULT_OK = 1;
@@ -83,7 +83,7 @@ public class IssueActivity extends AppCompatActivity {
     private boolean mShowServerError = false;
 
     private Issue mIssue;
-    private boolean mIsLowAccuracy = false;
+    private boolean mIsDistrictSplit = false;
     private boolean mDonateIsOn = false;
     private boolean mIsAnimating = false;
 
@@ -101,7 +101,7 @@ public class IssueActivity extends AppCompatActivity {
             finish();
             return;
         }
-        mIsLowAccuracy = getIntent().getBooleanExtra(KEY_IS_LOW_ACCURACY, false);
+        mIsDistrictSplit = getIntent().getBooleanExtra(KEY_IS_DISTRICT_SPLIT, false);
         mDonateIsOn = getIntent().getBooleanExtra(KEY_DONATE_IS_ON, false);
 
         setContentView(binding.getRoot());
@@ -244,7 +244,7 @@ public class IssueActivity extends AppCompatActivity {
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelable(KEY_ISSUE, mIssue);
-        outState.putBoolean(KEY_IS_LOW_ACCURACY, mIsLowAccuracy);
+        outState.putBoolean(KEY_IS_DISTRICT_SPLIT, mIsDistrictSplit);
     }
 
     @Override
@@ -459,7 +459,7 @@ public class IssueActivity extends AppCompatActivity {
         contactWarning.setVisibility(View.GONE);
         if (!TextUtils.isEmpty(contact.reason)) {
             contactReason.setText(contact.reason);
-            if (TextUtils.equals(contact.area, Contact.AREA_HOUSE) && mIsLowAccuracy) {
+            if (TextUtils.equals(contact.area, Contact.AREA_HOUSE) && mIsDistrictSplit) {
                 contactWarning.setVisibility(View.VISIBLE);
                 contactWarning.setText(R.string.low_accuracy_warning);
             }

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/LocationActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/LocationActivity.java
@@ -32,7 +32,7 @@ import org.a5calls.android.a5calls.model.AccountManager;
 
 import java.util.Objects;
 
-import static org.a5calls.android.a5calls.controller.IssueActivity.KEY_IS_LOW_ACCURACY;
+import static org.a5calls.android.a5calls.controller.IssueActivity.KEY_IS_DISTRICT_SPLIT;
 
 public class LocationActivity extends AppCompatActivity {
     private static final String TAG = "LocationActivity";
@@ -98,9 +98,9 @@ public class LocationActivity extends AppCompatActivity {
                 }
                 allowsHomeUp = true;
             }
-            boolean isLowAccuracy = intent.getBooleanExtra(KEY_IS_LOW_ACCURACY, false);
-            if (isLowAccuracy) {
-                binding.lowAccuracySuggestion.setVisibility(View.VISIBLE);
+            boolean isDistrictSplit = intent.getBooleanExtra(KEY_IS_DISTRICT_SPLIT, false);
+            if (isDistrictSplit) {
+                binding.districtSplitSuggestion.setVisibility(View.VISIBLE);
             }
         }
 

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/MainActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/MainActivity.java
@@ -86,6 +86,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
     private String mLocationName;
     private String mDistrictId;
     private boolean mIsDistrictSplit = false;
+    private boolean mIsLowAccuracy = false;
     private boolean mShowLowAccuracyWarning = true;
     private boolean mDonateIsOn = false;
     private FirebaseAuth mAuth = null;
@@ -374,6 +375,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
         issueIntent.putExtra(RepCallActivity.KEY_ADDRESS, getLocationString());
         issueIntent.putExtra(RepCallActivity.KEY_LOCATION_NAME, mLocationName);
         issueIntent.putExtra(IssueActivity.KEY_IS_DISTRICT_SPLIT, mIsDistrictSplit);
+        issueIntent.putExtra(IssueActivity.KEY_IS_LOW_ACCURACY, mIsLowAccuracy);
         issueIntent.putExtra(IssueActivity.KEY_DONATE_IS_ON, mDonateIsOn);
         startActivityForResult(issueIntent, ISSUE_DETAIL_REQUEST);
     }
@@ -421,6 +423,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
         Intent intent = new Intent(this, LocationActivity.class);
         intent.putExtra(LocationActivity.ALLOW_HOME_UP_KEY, true);
         intent.putExtra(IssueActivity.KEY_IS_DISTRICT_SPLIT, mIsDistrictSplit);
+        intent.putExtra(IssueActivity.KEY_IS_LOW_ACCURACY, mIsLowAccuracy);
         startActivity(intent);
     }
 
@@ -483,7 +486,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
 
             @Override
             public void onContactsReceived(String locationName, String districtId,
-                                           boolean isDistrictSplit, List<Contact> contacts, boolean stateChanged) {
+                                           boolean isDistrictSplit, boolean isLowAccuracy, List<Contact> contacts, boolean stateChanged) {
                 mLocationName = TextUtils.isEmpty(locationName) ?
                         getResources().getString(R.string.unknown_location) : locationName;
                 mDistrictId = districtId;
@@ -491,6 +494,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
                         R.string.title_main), mLocationName));
                 mIssuesAdapter.setContacts(contacts, IssuesAdapter.NO_ERROR);
                 mIsDistrictSplit = isDistrictSplit;
+                mIsLowAccuracy = isLowAccuracy;
 
                 hideSnackbars();
 

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/MainActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/MainActivity.java
@@ -85,7 +85,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
     private String mLongitude;
     private String mLocationName;
     private String mDistrictId;
-    private boolean mIsLowAccuracy = false;
+    private boolean mIsDistrictSplit = false;
     private boolean mShowLowAccuracyWarning = true;
     private boolean mDonateIsOn = false;
     private FirebaseAuth mAuth = null;
@@ -373,7 +373,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
         issueIntent.putExtra(IssueActivity.KEY_ISSUE, issue);
         issueIntent.putExtra(RepCallActivity.KEY_ADDRESS, getLocationString());
         issueIntent.putExtra(RepCallActivity.KEY_LOCATION_NAME, mLocationName);
-        issueIntent.putExtra(IssueActivity.KEY_IS_LOW_ACCURACY, mIsLowAccuracy);
+        issueIntent.putExtra(IssueActivity.KEY_IS_DISTRICT_SPLIT, mIsDistrictSplit);
         issueIntent.putExtra(IssueActivity.KEY_DONATE_IS_ON, mDonateIsOn);
         startActivityForResult(issueIntent, ISSUE_DETAIL_REQUEST);
     }
@@ -420,7 +420,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
 
         Intent intent = new Intent(this, LocationActivity.class);
         intent.putExtra(LocationActivity.ALLOW_HOME_UP_KEY, true);
-        intent.putExtra(IssueActivity.KEY_IS_LOW_ACCURACY, mIsLowAccuracy);
+        intent.putExtra(IssueActivity.KEY_IS_DISTRICT_SPLIT, mIsDistrictSplit);
         startActivity(intent);
     }
 
@@ -483,14 +483,14 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
 
             @Override
             public void onContactsReceived(String locationName, String districtId,
-                                           boolean isLowAccuracy, List<Contact> contacts, boolean stateChanged) {
+                                           boolean isDistrictSplit, List<Contact> contacts, boolean stateChanged) {
                 mLocationName = TextUtils.isEmpty(locationName) ?
                         getResources().getString(R.string.unknown_location) : locationName;
                 mDistrictId = districtId;
                 binding.collapsingToolbar.setTitle(String.format(getResources().getString(
                         R.string.title_main), mLocationName));
                 mIssuesAdapter.setContacts(contacts, IssuesAdapter.NO_ERROR);
-                mIsLowAccuracy = isLowAccuracy;
+                mIsDistrictSplit = isDistrictSplit;
 
                 hideSnackbars();
 
@@ -502,7 +502,7 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
                             houseCount++;
                         }
                     }
-                    if (houseCount > 1 || mIsLowAccuracy) {
+                    if (houseCount > 1 || mIsDistrictSplit) {
                         int warning = houseCount > 1 ? R.string.split_district_warning :
                                 R.string.low_accuracy_warning;
                         mSnackbar = Snackbar.make(binding.drawerLayout, warning,

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/net/FiveCallsApi.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/net/FiveCallsApi.java
@@ -85,7 +85,7 @@ public class FiveCallsApi {
         void onAddressError();
 
         void onContactsReceived(String locationName, String districtId, boolean isDistrictSplit,
-                                List<Contact> contacts, boolean stateChanged);
+                                boolean isLowAccuracy, List<Contact> contacts, boolean stateChanged);
     }
 
     public interface NewsletterSubscribeCallback {
@@ -211,10 +211,14 @@ public class FiveCallsApi {
                     if (response != null) {
                         String locationName = "";
                         boolean isDistrictSplit = false;
+                        boolean isLowAccuracy = false;
                         try {
                             locationName = response.getString("location");
                             if (response.has("isSplit")) {
                                 isDistrictSplit = response.getBoolean("isSplit");
+                            }
+                            if (response.has("lowAccuracy")) {
+                                isLowAccuracy = response.getBoolean("lowAccuracy");
                             }
                         } catch (JSONException e) {
                             for (ContactsRequestListener listener : listeners) {
@@ -257,7 +261,7 @@ public class FiveCallsApi {
 
                         for (ContactsRequestListener listener : listeners) {
                             listener.onContactsReceived(locationName, districtId, isDistrictSplit,
-                                    contacts, stateChanged);
+                                    isLowAccuracy, contacts, stateChanged);
                         }
                     }
                 }

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/net/FiveCallsApi.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/net/FiveCallsApi.java
@@ -84,7 +84,7 @@ public class FiveCallsApi {
 
         void onAddressError();
 
-        void onContactsReceived(String locationName, String districtId, boolean isLowAccuracy,
+        void onContactsReceived(String locationName, String districtId, boolean isDistrictSplit,
                                 List<Contact> contacts, boolean stateChanged);
     }
 
@@ -210,11 +210,11 @@ public class FiveCallsApi {
                 public void onResponse(JSONObject response) {
                     if (response != null) {
                         String locationName = "";
-                        boolean lowAccuracy = false;
+                        boolean isDistrictSplit = false;
                         try {
                             locationName = response.getString("location");
                             if (response.has("isSplit")) {
-                                lowAccuracy = response.getBoolean("isSplit");
+                                isDistrictSplit = response.getBoolean("isSplit");
                             }
                         } catch (JSONException e) {
                             for (ContactsRequestListener listener : listeners) {
@@ -256,7 +256,7 @@ public class FiveCallsApi {
                         }
 
                         for (ContactsRequestListener listener : listeners) {
-                            listener.onContactsReceived(locationName, districtId, lowAccuracy,
+                            listener.onContactsReceived(locationName, districtId, isDistrictSplit,
                                     contacts, stateChanged);
                         }
                     }

--- a/5calls/app/src/main/res/layout/activity_location.xml
+++ b/5calls/app/src/main/res/layout/activity_location.xml
@@ -65,8 +65,8 @@
 
             <TextView
                 style="@style/spacedParagraphTextStyleErrorHighlight"
-                android:id="@+id/low_accuracy_suggestion"
-                android:text="@string/low_accuracy_suggestion"
+                android:id="@+id/district_split_suggestion"
+                android:text="@string/split_district_suggestion"
                 android:visibility="gone"
                 />
 

--- a/5calls/app/src/main/res/values-es/strings.xml
+++ b/5calls/app/src/main/res/values-es/strings.xml
@@ -359,7 +359,7 @@
     <string name="rep_section_prompt">Contactos para llamar hoy</string>
 
     <!-- Warning that you may be in a split district [CHAR_LIMIT=90] -->
-    <string name="split_district_warning">Su código postal tiene varios representantes. Esta es nuestra mejor suposición.</string>
+    <string name="split_district_warning">Su código postal abarca varios distritos, use código+4 o dirección completa.</string>
 
     <!-- Warning that you have a low accuracy location [CHAR_LIMIT=90] -->
     <string name="low_accuracy_warning">Su ubicación no es lo suficientemente precisa para garantizar que tengamos al representante de la Cámara adecuado.</string>

--- a/5calls/app/src/main/res/values-es/strings.xml
+++ b/5calls/app/src/main/res/values-es/strings.xml
@@ -364,6 +364,9 @@
     <!-- Warning that you have a low accuracy location [CHAR_LIMIT=90] -->
     <string name="low_accuracy_warning">Su ubicación no es lo suficientemente precisa para garantizar que tengamos al representante de la Cámara adecuado.</string>
 
+    <!-- Warning for low accuracy location in issue activity [CHAR_LIMIT=NONE] -->
+    <string name="low_accuracy_state_rep_warning">Advertencia: su ubicación está configurada en un código postal u otra ubicación aproximada, ingrese una dirección o código postal+4 para representantes estatales precisos.</string>
+
     <!-- Shown on the set location page above the address text field if the zip is low accuracy [CHAR_LIMIT=NONE] -->
     <string name="split_district_suggestion">Utilice su código postal + 4 o una dirección para identificar a su representante exacto.</string>
 

--- a/5calls/app/src/main/res/values-es/strings.xml
+++ b/5calls/app/src/main/res/values-es/strings.xml
@@ -365,7 +365,7 @@
     <string name="low_accuracy_warning">Su ubicación no es lo suficientemente precisa para garantizar que tengamos al representante de la Cámara adecuado.</string>
 
     <!-- Shown on the set location page above the address text field if the zip is low accuracy [CHAR_LIMIT=NONE] -->
-    <string name="low_accuracy_suggestion">Utilice su código postal + 4 o una dirección para identificar a su representante exacto.</string>
+    <string name="split_district_suggestion">Utilice su código postal + 4 o una dirección para identificar a su representante exacto.</string>
 
     <!-- Action for a snackbar or button which brings you to the location update screen [CHAR_LIMIT=10] -->
     <string name="update">Actualización</string>

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -414,7 +414,7 @@
     <string name="rep_section_prompt">Contacts to call today</string>
 
     <!-- Warning that you may be in a split district [CHAR_LIMIT=90] -->
-    <string name="split_district_warning">Your zip code has multiple house representatives. This is our best guess.</string>
+    <string name="split_district_warning">Your zip code matches multiple House districts, use a zip+4 or address for best results.</string>
 
     <!-- Warning that you have a low accuracy location [CHAR_LIMIT=90] -->
     <string name="low_accuracy_warning">Your zip is not precise enough to ensure we\'ve got the right House representative.</string>

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -420,7 +420,7 @@
     <string name="low_accuracy_warning">Your zip is not precise enough to ensure we\'ve got the right House representative.</string>
 
     <!-- Shown on the set location page above the address text field if the zip is low accuracy [CHAR_LIMIT=NONE] -->
-    <string name="low_accuracy_suggestion">Use your zip + 4 or an address to get an accurate representative.</string>
+    <string name="split_district_suggestion">Use your zip + 4 or an address to get an accurate representative.</string>
 
     <!-- Action for a snackbar or button which brings you to the location update screen [CHAR_LIMIT=10] -->
     <string name="update">update</string>

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -419,6 +419,9 @@
     <!-- Warning that you have a low accuracy location [CHAR_LIMIT=90] -->
     <string name="low_accuracy_warning">Your zip is not precise enough to ensure we\'ve got the right House representative.</string>
 
+    <!-- Warning for low accuracy location in issue activity [CHAR_LIMIT=NONE] -->
+    <string name="low_accuracy_state_rep_warning">Warning: your location is set to a zip code or other approximate location, please enter an address or zip+4 for accurate state level reps.</string>
+
     <!-- Shown on the set location page above the address text field if the zip is low accuracy [CHAR_LIMIT=NONE] -->
     <string name="split_district_suggestion">Use your zip + 4 or an address to get an accurate representative.</string>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

Updates #257, when state reps are listed as a contact type, zip codes or other low accuracy methods of location finding are **very** likely to give a wrong representative. Shows a warning in the contact list for state reps only when using low accuracy locations.

![Screenshot_20250927-104125~2](https://github.com/user-attachments/assets/9854298e-ff54-4e78-87f3-7be8ee56c640)

## Were the changes tested?

- [ ] Yes, automated tests in _please name test methods or files_
- [x] Yes, manually tested: Used 32008 as a Florida zip code, got some state level issues with state reps listed. The warning shows. Update location to 12223 co rd, wellborn FL (same state house and senate district, same reps) and warning no longer shows.
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
