### PR TITLE
Add state to filter categories, if present

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/adapter/IssuesAdapter.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/adapter/IssuesAdapter.java
@@ -16,7 +16,6 @@ import org.a5calls.android.a5calls.model.Category;
 import org.a5calls.android.a5calls.model.Contact;
 import org.a5calls.android.a5calls.model.DatabaseHelper;
 import org.a5calls.android.a5calls.model.Issue;
-import org.a5calls.android.a5calls.util.StateMapping;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -131,7 +130,7 @@ public class IssuesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
                 mIssues = sortIssuesWithMetaPriority(filterActiveIssues());
             } else {
                 // Filter by the category string.
-                mIssues = sortIssuesWithMetaPriority(filterIssuesByCategory(filterText));
+                mIssues = sortIssuesWithMetaPriority(filterIssuesByCategory(mAllIssues, filterText));
             }
         }
         notifyDataSetChanged();
@@ -213,9 +212,15 @@ public class IssuesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         return tempIssues;
     }
 
-    private ArrayList<Issue> filterIssuesByCategory(String activeCategory) {
+    @VisibleForTesting
+    public static ArrayList<Issue> filterIssuesByCategory(List<Issue> issues, String activeCategory) {
         ArrayList<Issue> tempIssues = new ArrayList<>();
-        for (Issue issue : mAllIssues) {
+        for (Issue issue : issues) {
+            // Categories include state.
+            if (TextUtils.equals(issue.getStateName(), activeCategory)) {
+                tempIssues.add(issue);
+                continue;
+            }
             for (Category category : issue.categories) {
                 if (TextUtils.equals(activeCategory, category.name)) {
                     tempIssues.add(issue);
@@ -314,16 +319,11 @@ public class IssuesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
             final Issue issue = mIssues.get(position);
             vh.name.setText(issue.name);
 
-            // Show state indicator if issue has meta (state abbreviation) and we can map it to a state name
-            if (!TextUtils.isEmpty(issue.meta)) {
-                String stateName = StateMapping.getStateName(issue.meta);
-                if (!TextUtils.isEmpty(stateName)) {
-                    vh.stateIndicator.setText(stateName);
-                    vh.stateIndicator.setVisibility(View.VISIBLE);
-
-                } else {
-                    vh.stateIndicator.setVisibility(View.GONE);
-                }
+            // Show state indicator if issue has a state set.
+            String stateName = issue.getStateName();
+            if (!TextUtils.isEmpty(stateName)) {
+                vh.stateIndicator.setText(stateName);
+                vh.stateIndicator.setVisibility(View.VISIBLE);
             } else {
                 vh.stateIndicator.setVisibility(View.GONE);
             }

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/MainActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/MainActivity.java
@@ -613,6 +613,11 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
             if (issue.categories == null) {
                 continue;
             }
+            // Add state items filter.
+            String state = issue.getStateName();
+            if (!TextUtils.isEmpty(state) && !topics.contains(state)) {
+                topics.add(state);
+            }
             for (Category category : issue.categories) {
                 if (!topics.contains(category.name)) {
                     topics.add(category.name);

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/model/Issue.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/model/Issue.java
@@ -4,7 +4,11 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import org.a5calls.android.a5calls.util.StateMapping;
+
 import java.util.List;
+
+import androidx.annotation.Nullable;
 
 /**
  * Represents an issue.
@@ -103,5 +107,12 @@ public class Issue implements Parcelable {
             }
         }
         return script;
+    }
+
+    public @Nullable String getStateName() {
+        if (TextUtils.isEmpty(meta)) {
+            return null;
+        }
+        return StateMapping.getStateName(meta);
     }
 }

--- a/5calls/app/src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java
+++ b/5calls/app/src/test/java/org/a5calls/android/a5calls/adapter/IssuesAdapterTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -28,18 +29,14 @@ public class IssuesAdapterTest {
 
     @Test
     public void testFilterIssuesBySearchText_noMatches() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(FakeJSONData.ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("Pizza", issues);
         assertEquals(0, filtered.size());
     }
 
     @Test
     public void testFilterIssuesBySearchText_matchesCategory() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(FakeJSONData.ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText(
                 "Government Oversight", issues);
         assertEquals(2, filtered.size());
@@ -47,9 +44,7 @@ public class IssuesAdapterTest {
 
     @Test
     public void testFilterIssuesBySearchText_matchesCategory_ignoresCapitalization() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(FakeJSONData.ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText(
                 "gOvErNmEnT oVeRsIgHt", issues);
         assertEquals(2, filtered.size());
@@ -57,45 +52,35 @@ public class IssuesAdapterTest {
 
     @Test
     public void testFilterIssuesBySearchText_matchesCategoryAndReason() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(FakeJSONData.ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("healthcare", issues);
         assertEquals(4, filtered.size());
     }
 
     @Test
     public void testFilterIssuesBySearchText_matchesTitle() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(FakeJSONData.ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("stop h.r. 722", issues);
         assertEquals(1, filtered.size());
     }
 
     @Test
     public void testFilterIssuesBySearchText_matchesReason() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(FakeJSONData.ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("displacement", issues);
         assertEquals(1, filtered.size());
     }
 
     @Test
     public void testFilterIssuesBySearchText_matchesReason_twoWords() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(FakeJSONData.ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("Trump admin", issues);
         assertEquals(4, filtered.size());
     }
 
     @Test
     public void testFilterIssuesBySearchText_matchesReason_doesNotMatchIfNotStartOfWord() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(FakeJSONData.ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(FakeJSONData.ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("isplacement", issues);
         assertEquals(0, filtered.size());
     }
@@ -135,36 +120,28 @@ public class IssuesAdapterTest {
      */
     @Test
     public void testFilterIssuesBySearchText_matchesTitle_doesMatchEndOfWord() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(REGEX_TEST_ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("over", issues);
         assertEquals(1, filtered.size());
     }
 
     @Test
     public void testFilterIssuesBySearchText_matchesReason_matchesStartOfFirstWord() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(REGEX_TEST_ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("During", issues);
         assertEquals(1, filtered.size());
     }
 
     @Test
     public void testFilterIssuesBySearchText_matchesReason_matchesWordPrefixes() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(REGEX_TEST_ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("Press Conf", issues);
         assertEquals(1, filtered.size());
     }
 
     @Test
     public void testFilterIssuesBySearchText_matchesReason_noCrashIfSearchTextIsInvalidRegex() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(REGEX_TEST_ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText("[", issues);
         assertEquals(0, filtered.size());
         String regexQuotePattern = "\\E[";
@@ -176,9 +153,7 @@ public class IssuesAdapterTest {
 
     @Test
     public void testFilterIssuesBySearchText_matchesReason_searchTextNotInterpretedAsRegexPattern() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(REGEX_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(REGEX_TEST_ISSUE_DATA);
         List<Issue> filtered = IssuesAdapter.filterIssuesBySearchText(".", issues);
         assertEquals(0, filtered.size());
     }
@@ -191,7 +166,7 @@ public class IssuesAdapterTest {
             "name": "Regular Issue A",
             "reason": "Regular issue without meta",
             "script": "Test script",
-            "categories": [{"name": "Test"}],
+            "categories": [{"name": "Test"}, {"name": "Test2"}],
             "contactType": "REPS",
             "contactAreas": ["US House"],
             "outcomeModels": [],
@@ -254,10 +229,8 @@ public class IssuesAdapterTest {
 
     @Test
     public void testSortIssuesWithMetaPriority_allWithoutMeta() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(ORDERING_TEST_ISSUE_DATA, listType);
-        
+        List<Issue> issues = issuesFromJson(ORDERING_TEST_ISSUE_DATA);
+
         // Remove meta from all issues
         for (Issue issue : issues) {
             issue.meta = "";
@@ -277,10 +250,8 @@ public class IssuesAdapterTest {
 
     @Test
     public void testSortIssuesWithMetaPriority_allWithMeta() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(ORDERING_TEST_ISSUE_DATA, listType);
-        
+        List<Issue> issues = issuesFromJson(ORDERING_TEST_ISSUE_DATA);
+
         // Add meta to all issues
         issues.get(0).meta = "TX";
         issues.get(2).meta = "FL";
@@ -302,10 +273,8 @@ public class IssuesAdapterTest {
 
     @Test
     public void testSortIssuesWithMetaPriority_mixedMetaValues() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(ORDERING_TEST_ISSUE_DATA, listType);
-        
+        List<Issue> issues = issuesFromJson(ORDERING_TEST_ISSUE_DATA);
+
         IssuesAdapter adapter = new IssuesAdapter(null, null);
         ArrayList<Issue> result = adapter.sortIssuesWithMetaPriority(issues);
         
@@ -330,10 +299,8 @@ public class IssuesAdapterTest {
 
     @Test
     public void testSortIssuesWithMetaPriority_nullMetaHandling() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(ORDERING_TEST_ISSUE_DATA, listType);
-        
+        List<Issue> issues = issuesFromJson(ORDERING_TEST_ISSUE_DATA);
+
         // Set some meta to null
         issues.get(0).meta = null;
         issues.get(2).meta = null;
@@ -352,6 +319,36 @@ public class IssuesAdapterTest {
         // Issues with null/empty meta come last (sorted by sort: 100(300), 300(400))
         assertEquals("100", result.get(2).id);
         assertEquals("300", result.get(3).id);
+    }
+
+    @Test
+    public void testFilterIssuesByCategoryNoMatch() {
+        List<Issue> issues = issuesFromJson(ORDERING_TEST_ISSUE_DATA);
+        List<Issue> filtered = IssuesAdapter.filterIssuesByCategory(issues,"banana");
+        assertTrue(filtered.isEmpty());
+    }
+
+    @Test
+    public void testFilterIssuesByCategoryMatchesCategoryForMany() {
+        List<Issue> issues = issuesFromJson(ORDERING_TEST_ISSUE_DATA);
+        List<Issue> filtered = IssuesAdapter.filterIssuesByCategory(issues,"Test");
+        assertEquals(4, filtered.size());
+    }
+
+    @Test
+    public void testFilterIssuesByCategoryMatchesCategoryForOne() {
+        List<Issue> issues = issuesFromJson(ORDERING_TEST_ISSUE_DATA);
+        List<Issue> filtered = IssuesAdapter.filterIssuesByCategory(issues, "Test2");
+        assertEquals(1, filtered.size());
+        assertEquals("100", filtered.getFirst().id);
+    }
+
+    @Test
+    public void testFilterIssuesByCategoryMatchesState() {
+        List<Issue> issues = issuesFromJson(ORDERING_TEST_ISSUE_DATA);
+        List<Issue> filtered = IssuesAdapter.filterIssuesByCategory(issues,"California");
+        assertEquals(1, filtered.size());
+        assertEquals("200", filtered.getFirst().id);
     }
 
     // Test data for populateIssueContacts tests
@@ -400,9 +397,7 @@ public class IssuesAdapterTest {
 
     @Test
     public void testPopulateIssueContacts_basicAssignment() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(CONTACTS_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(CONTACTS_TEST_ISSUE_DATA);
         Issue issue = issues.getFirst();
 
         List<Contact> contacts = new ArrayList<>();
@@ -430,9 +425,7 @@ public class IssuesAdapterTest {
 
     @Test
     public void testPopulateIssueContacts_splitDistrict() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(CONTACTS_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(CONTACTS_TEST_ISSUE_DATA);
         Issue issue = issues.getFirst();
 
         List<Contact> contacts = new ArrayList<>();
@@ -449,9 +442,7 @@ public class IssuesAdapterTest {
 
     @Test
     public void testPopulateIssueContacts_emptyContactAreas() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(CONTACTS_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(CONTACTS_TEST_ISSUE_DATA);
         Issue issue = issues.get(2);
 
         List<Contact> contacts = new ArrayList<>();
@@ -468,9 +459,7 @@ public class IssuesAdapterTest {
 
     @Test
     public void testPopulateIssueContacts_noMatchingContacts() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(CONTACTS_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(CONTACTS_TEST_ISSUE_DATA);
         Issue issue = issues.getFirst();
 
         List<Contact> contacts = new ArrayList<>();
@@ -487,11 +476,8 @@ public class IssuesAdapterTest {
 
     @Test
     public void testPopulateIssueContacts_noDuplicates() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(CONTACTS_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(CONTACTS_TEST_ISSUE_DATA);
         Issue issue = issues.get(1);
-
         List<Contact> contacts = new ArrayList<>();
         Contact senator = Contact.createPlaceholder("sen1", "Senator A", "", "US Senate");
         senator.isPlaceholder = false;
@@ -508,9 +494,7 @@ public class IssuesAdapterTest {
 
     @Test
     public void testPopulateIssueContacts_noLocation() {
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
-        List<Issue> issues = gson.fromJson(CONTACTS_TEST_ISSUE_DATA, listType);
+        List<Issue> issues = issuesFromJson(CONTACTS_TEST_ISSUE_DATA);
         Issue issue = issues.get(1);
         assertNull(issue.contacts);
 
@@ -519,5 +503,11 @@ public class IssuesAdapterTest {
         adapter.populateIssueContacts(issue);
 
         assertNull(issue.contacts);
+    }
+
+    private List<Issue> issuesFromJson(String json) {
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        Type listType = new TypeToken<ArrayList<Issue>>(){}.getType();
+        return gson.fromJson(json, listType);
     }
 }

--- a/5calls/app/src/test/java/org/a5calls/android/a5calls/model/IssueTest.java
+++ b/5calls/app/src/test/java/org/a5calls/android/a5calls/model/IssueTest.java
@@ -183,4 +183,22 @@ public class IssueTest {
         assertEquals("Custom script for contact 1", issue.getScriptForContact("contact1"));
         assertNull(issue.getScriptForContact("nonexistent_contact"));
     }
+
+    @Test
+    public void testGetStateNameNoState() {
+        Issue issue = TestModelUtils.createIssue("test-issue", "Test Issue", "");
+        assertNull(issue.getStateName());
+    }
+
+    @Test
+    public void testGetStateNameWithNoStateMapping() {
+        Issue issue = TestModelUtils.createIssue("test-issue", "Test Issue", "ba");
+        assertNull(issue.getStateName());
+    }
+
+    @Test
+    public void testGetStateNameWithStateSet() {
+        Issue issue = TestModelUtils.createIssue("test-issue", "Test Issue", "ca");
+        assertEquals("California", issue.getStateName());
+    }
 }

--- a/5calls/app/src/test/java/org/a5calls/android/a5calls/model/TestModelUtils.java
+++ b/5calls/app/src/test/java/org/a5calls/android/a5calls/model/TestModelUtils.java
@@ -20,9 +20,14 @@ public class TestModelUtils {
     }
 
     public static Issue createIssue(String id, String name) {
+        return createIssue(id, name, "");
+    }
+
+    public static Issue createIssue(String id, String name, String meta) {
         Issue issue = Issue.CREATOR.createFromParcel(Parcel.obtain());
         issue.id = id;
         issue.name = name;
+        issue.meta = meta;
         return issue;
     }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

If state-level issues are present, adds the state to the list of items to filter by. Moves state name getting logic from IssuesAdapter to Issue.java so it can be reused; adds unit tests.

Also refactors common lines into helper in IssuesAdapterTest.

## Were the changes tested?

- [x] Yes, automated tests in issuetest and issuesadaptertest
- [x] Yes, manually tested: pixel 9 emulator, with location with and without state issues
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
