### PR TITLE
Show a list of relevant rep types on the issue details page

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
@@ -573,7 +573,8 @@ public class IssueActivity extends AppCompatActivity implements FiveCallsApi.Scr
         binding.repList.removeAllViews();
         binding.relevantRepText.setVisibility(mIssue.contacts.isEmpty() ? View.GONE : View.VISIBLE);
         binding.relevantRepText.setText(
-                getResources().getString(R.string.relevant_reps,
+                getResources().getString(
+                        mIssue.contacts.size() == 1 ? R.string.relevant_rep : R.string.relevant_reps,
                 IssuesAdapter.areasToCallsOverviewString(this, mIssue.contactAreas)));
         boolean allCalled = true;
         DatabaseHelper dbHelper = AppSingleton.getInstance(this).getDatabaseHelper();

--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/IssueActivity.java
@@ -571,6 +571,10 @@ public class IssueActivity extends AppCompatActivity implements FiveCallsApi.Scr
      */
     private boolean loadRepList() {
         binding.repList.removeAllViews();
+        binding.relevantRepText.setVisibility(mIssue.contacts.isEmpty() ? View.GONE : View.VISIBLE);
+        binding.relevantRepText.setText(
+                getResources().getString(R.string.relevant_reps,
+                IssuesAdapter.areasToCallsOverviewString(this, mIssue.contactAreas)));
         boolean allCalled = true;
         DatabaseHelper dbHelper = AppSingleton.getInstance(this).getDatabaseHelper();
 

--- a/5calls/app/src/main/res/layout/activity_issue.xml
+++ b/5calls/app/src/main/res/layout/activity_issue.xml
@@ -137,6 +137,14 @@
                 android:showDividers="middle"
                 />
 
+            <TextView
+                style="@style/repListItemStyle"
+                android:id="@+id/relevant_rep_text"
+                android:textColor="@color/colorPrimaryDark"
+                android:textStyle="bold"
+                android:textSize="@dimen/min_resizable_text_size"
+                />
+
             <RelativeLayout
                 android:id="@+id/no_calls_left"
                 style="@style/issueRelativeLayoutStyle"

--- a/5calls/app/src/main/res/values-es/strings.xml
+++ b/5calls/app/src/main/res/values-es/strings.xml
@@ -54,6 +54,12 @@
     <!-- Message to the user that no calls are left on a particular issue [CHAR_LIMIT=NONE] -->
     <string name="no_location_set">No hay contactos disponibles</string>
 
+    <!-- Informs the user of the contacts that is relevant to a particular issue CHAR_LIMIT=100] -->
+    <string name="relevant_rep">Contacto relevante: <xliff:g id="contact">%1$s</xliff:g></string>
+
+    <!-- Informs the user of the list of contacts that are relevant to a particular issue CHAR_LIMIT=100] -->
+    <string name="relevant_reps">Contactos relevantes: <xliff:g id="contacts_list">%1$s</xliff:g></string>
+
     <!-- Message to the user when no location is set, prompting them to set a location. [CHAR_LIMIT=NONE] -->
     <string name="error_no_location_set">Establece tu ubicación para encontrar a tus representantes.</string>
 

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -57,6 +57,10 @@
     <!-- Message to the user when no location is set, prompting them to set a location. [CHAR_LIMIT=NONE] -->
     <string name="error_no_location_set">Set your location to find your representatives.</string>
 
+    <!-- Informs the user of the contacts that is relevant to a particular issue CHAR_LIMIT=100] -->
+    <string name="relevant_rep">Relevant contact: <xliff:g id="contact">%1$s</xliff:g></string>
+
+    <!-- Informs the user of the list of contacts that are relevant to a particular issue CHAR_LIMIT=100] -->
     <string name="relevant_reps">Relevant contacts: <xliff:g id="contacts_list">%1$s</xliff:g></string>
 
     <!-- Menu option to go to the About 5 Calls screen [CHAR_LIMIT=25] -->

--- a/5calls/app/src/main/res/values/strings.xml
+++ b/5calls/app/src/main/res/values/strings.xml
@@ -57,6 +57,8 @@
     <!-- Message to the user when no location is set, prompting them to set a location. [CHAR_LIMIT=NONE] -->
     <string name="error_no_location_set">Set your location to find your representatives.</string>
 
+    <string name="relevant_reps">Relevant contacts: <xliff:g id="contacts_list">%1$s</xliff:g></string>
+
     <!-- Menu option to go to the About 5 Calls screen [CHAR_LIMIT=25] -->
     <string name="menu_about">About 5 Calls</string>
 

--- a/5calls/app/src/main/res/values/styles.xml
+++ b/5calls/app/src/main/res/values/styles.xml
@@ -380,14 +380,17 @@
         <item name="android:layout_marginStart">@dimen/margin_top4</item>
     </style>
 
-    <style name="repListRelativeStyle" parent="BaseContainer">
-        <item name="android:layout_height">@dimen/load_more_height</item>
-        <item name="android:minHeight">@dimen/accessibility_min_size</item>
+    <style name="repListItemStyle" parent="BaseContainer">
         <item name="android:paddingBottom">@dimen/rep_list_dimens</item>
         <item name="android:paddingTop">@dimen/rep_list_dimens</item>
         <item name="android:paddingStart">@dimen/rep_list_dimens_left_right</item>
         <item name="android:paddingEnd">@dimen/rep_list_dimens_left_right</item>
         <item name="android:background">@color/issue_background_color</item>
+    </style>
+
+    <style name="repListRelativeStyle" parent="repListItemStyle">
+        <item name="android:layout_height">@dimen/load_more_height</item>
+        <item name="android:minHeight">@dimen/accessibility_min_size</item>
         <item name="android:foreground">?android:attr/selectableItemBackground</item>
     </style>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

Shows a summary of which reps are relevant beneath the contacts list in the issue details page. Will also create vertical space for undo snackbar to fit.

<img width="306" height="183" alt="image" src="https://github.com/user-attachments/assets/6680c0c7-26c9-4983-a761-e237d4c5cdc4" />
<img width="308" height="262" alt="image" src="https://github.com/user-attachments/assets/28033130-670f-4748-9a23-7a45b259d053" />

## Related Issues

- Related Issue #
- Closes #246

## Were the changes tested?

- [ ] Yes, automated tests in _please name test methods or files_
- [x] Yes, manually tested: looked at issues with 1, 2, and 5 contacts
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
