### PR TITLE
removed inset compounding issue

### DIFF
--- a/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/MainActivity.java
+++ b/5calls/app/src/main/java/org/a5calls/android/a5calls/controller/MainActivity.java
@@ -159,9 +159,8 @@ public class MainActivity extends AppCompatActivity implements IssuesAdapter.Cal
                             WindowInsetsCompat.Type.displayCutout());
             binding.appbar.setPadding(insets.left, insets.top, insets.right, 0);
             binding.issuesRecyclerView.setPadding(insets.left, 0, insets.right, insets.bottom);
-            binding.filterBar.setPadding(
-                    binding.filterBar.getPaddingStart() + insets.left, binding.filterBar.getPaddingTop(),
-                    binding.filterBar.getPaddingEnd() + insets.right, binding.filterBar.getPaddingBottom());
+            binding.filterBar.setPadding(insets.left, binding.filterBar.getPaddingTop(),
+                    insets.right, binding.filterBar.getPaddingBottom());
             binding.searchBar.setPadding(insets.left, 0, insets.right, 0);
             final int sidePadding = getResources().getDimensionPixelSize(
                     R.dimen.activity_horizontal_margin);


### PR DESCRIPTION
This bug was a byproduct of switching from a spinner to the filter bar, and we switched the layout. Previously we needed to account for potential paddingStart and paddingEnd, but that need went away, and the way we were setting insets in landscape within a listener caused compounding padding. 

Tested in portrait and landscape, flipping back and forth and ensuring the filter icon stays left aligned. 

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization

## Description

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Were the changes tested?

- [ ] Yes, automated tests in _please name test methods or files_
- [ ] Yes, manually tested: _please provide steps performed to test changes_
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
